### PR TITLE
add overflow and custom scrollbar to popups

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -577,6 +577,7 @@ transform: translate(0px, -25px);
   border-radius:20px;
   box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
   transition: left 550ms ease;
+  overflow: auto; /* add scrollbar when content goes outside of popup (smaller displays) */
 }
 
 .popupheader {
@@ -758,4 +759,21 @@ p {
   margin-top:1vh;
   margin-right:1vh;
   text-align: center;
+}
+
+
+/* scrollbar bg */
+::-webkit-scrollbar-track { 
+  background: transparent;
+}
+/* scrollbar */
+::-webkit-scrollbar {
+  width: 10px;
+}
+::-webkit-scrollbar-thumb {
+  background: #d4d4d4;
+  border-radius: 20px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #bbbbbb; 
 }


### PR DESCRIPTION
issue: content in popups will overflow outside of popups: 
![image](https://user-images.githubusercontent.com/15159795/134265162-1e0d443c-66c0-4822-83a1-defd0b12ff88.png)

fix: add overflow to popups, style the scrollbar to fit with the aesthetic with the website:
![image](https://user-images.githubusercontent.com/15159795/134265214-b3e56542-d90a-48ef-aaf5-f8a3a0b7e3cc.png)
